### PR TITLE
Add JSON-driven vacation popup system

### DIFF
--- a/cenik.html
+++ b/cenik.html
@@ -14,21 +14,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
-     <!-- <div id="vacation-popup" class="popup">
-        <div class="popup-content">
-            <span class="close-popup">&times;</span>
-            <h3>Dovolená </h3>
-            <p>Vážení pacienti,</p>
-            <p>dovoluji si Vás informovat, že ordinace bude z důvodu dovolené uzavřena ve dnech <strong>25.11. (úterý) až 10.12.2025 (středa)</strong>.</p>
-            <p>Akutní neodkladnou péči Vám po předchozí telefonické domluvě zajistí lékařka v ordinaci Mediclinic v Milíně.</p>
-            <p>Telefon: <a href="tel:+420318691123">318 691 123</a></p>
-            <p>Email: <a href="mailto:praktik1-Milin@ordinace.mediclinic.cz">praktik1-Milin@ordinace.mediclinic.cz</a></p>
-            <p>Pokud se obracíte na zastupující lékařku, mějte vždy k dispozici své rodné číslo, číslo pojišťovny, názvy a síly léků, které užíváte.</p>
-            <p>Během dovolené se můžete s objednávkami obracet i na zdravotní sestru paní Macounovou na telefonu <a href="tel:+420725875487">725 875 487</a>.</p>
-            <p>Děkuji za pochopení.</p>
-        </div>
-    </div>  -->
-    
+    <div id="vacation-popup" class="popup"></div>
+
     <header>
         <div class="container">
             <div class="logo-container">
@@ -195,7 +182,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2023 MUDr. Ivana Šestáková - Všechna práva vyhrazena</p>
+                <p>&copy; 2025 MUDr. Ivana Šestáková - Všechna práva vyhrazena</p>
                 <p>Vytvořeno s <i class="fas fa-heart"></i></p>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -14,22 +14,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
-      <!-- <div id="vacation-popup" class="popup">
-        <div class="popup-content">
-            <span class="close-popup">&times;</span>
-            <h3>Dovolená </h3>
-            <p>Vážení pacienti,</p>
-            <p>dovoluji si Vás informovat, že ordinace bude z důvodu dovolené uzavřena ve dnech <strong>25.11. (úterý) až 10.12.2025 (středa)</strong>.</p>
-            <p>Akutní neodkladnou péči Vám po předchozí telefonické domluvě zajistí lékařka v ordinaci Mediclinic v Milíně.</p>
-            <p>Telefon: <a href="tel:+420318691123">318 691 123</a></p>
-            <p>Email: <a href="mailto:praktik1-Milin@ordinace.mediclinic.cz">praktik1-Milin@ordinace.mediclinic.cz</a></p>
-            <p>Pokud se obracíte na zastupující lékařku, mějte vždy k dispozici své rodné číslo, číslo pojišťovny, názvy a síly léků, které užíváte.</p>
-            <p>Během dovolené se můžete s objednávkami obracet i na zdravotní sestru paní Macounovou na telefonu <a href="tel:+420725875487">725 875 487</a>.</p>             
-            <p>Děkuji za pochopení.</p>
-        </div>
-    </div> -->
-    
-    
+    <div id="vacation-popup" class="popup"></div>
+
     <header>
         <div class="container">
             <div class="logo-container">
@@ -253,7 +239,7 @@
                     <i class="fas fa-envelope"></i>
                     <div>
                         <h3>E-mail</h3>
-                        <p><a href="mailto:sestakova.ivana@seznam.cz ">sestakova.ivana@seznam.cz </a></p>
+                        <p><a href="mailto:sestakova.ivana@seznam.cz">sestakova.ivana@seznam.cz</a></p>
                     </div>
                 </div>
             </div>
@@ -274,7 +260,7 @@
                             </div>
                         </div>
                         <div class="contact-map">
-                            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d646.290957857605!2d14.194380539064294!3d49.613515946680856!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x470b6dc392fba53b%3A0xe5917aa3fa53a641!2zT3JkaW5hY2UgcHJha3QuIGzDqWthxZllIHBybyBkb3NwxJtsw6k!5e0!3m2!1sen!2sau!4v1741391830262!5m2!1sen!2sau" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+                            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d646.290957857605!2d14.194380539064294!3d49.613515946680856!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x470b6dc392fba53b%3A0xe5917aa3fa53a641!2zT3JkaW5hY2UgcHJha3QuIGzDqWthxZllIHBybyBkb3NwxJtsw6k!5e0!3m2!1sen!2sau!4v1741391830262!5m2!1sen!2sau" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" title="Mapa ordinace Solenice"></iframe>
                         </div>
                     </div>
                 </div>
@@ -294,7 +280,7 @@
                             </div>
                         </div>
                         <div class="contact-map">
-                            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2588.0941011649147!2d14.1100048!3d49.5582476!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x470b6ba6f8518501%3A0xe6aefccab07e21c1!2zTVVEci4gSXZhbmEgxaBlc3TDoWtvdsOh!5e0!3m2!1sen!2sau!4v1741391289713!5m2!1sen!2sau" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+                            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2588.0941011649147!2d14.1100048!3d49.5582476!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x470b6ba6f8518501%3A0xe6aefccab07e21c1!2zTVVEci4gSXZhbmEgxaBlc3TDoWtvdsOh!5e0!3m2!1sen!2sau!4v1741391289713!5m2!1sen!2sau" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" title="Mapa ordinace Kozárovice"></iframe>
                         </div>
                     </div>
                 </div>
@@ -366,7 +352,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2023 MUDr. Ivana Šestáková - Všechna práva vyhrazena</p>
+                <p>&copy; 2025 MUDr. Ivana Šestáková - Všechna práva vyhrazena</p>
                 <p>Vytvořeno s <i class="fas fa-heart"></i></p>
             </div>
         </div>

--- a/js/script.js
+++ b/js/script.js
@@ -141,16 +141,6 @@ function escapeHtml(str) {
     return div.innerHTML;
 }
 
-function formatCzechDate(dateStr) {
-    var parts = dateStr.split('-');
-    var date = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
-    var day = date.getDate();
-    var month = date.getMonth() + 1;
-    var year = date.getFullYear();
-    var weekday = date.toLocaleDateString('cs-CZ', { weekday: 'long' });
-    return day + '.' + month + '. (' + weekday + ') ' + year;
-}
-
 function formatDateRange(startStr, endStr) {
     var startParts = startStr.split('-');
     var endParts = endStr.split('-');

--- a/vacation.json
+++ b/vacation.json
@@ -1,0 +1,7 @@
+{
+  "_instructions": "Set enabled to true and update dates (format: YYYY-MM-DD). Do not remove quotes or commas. Changes take 5-15 min to appear on the live site.",
+  "enabled": false,
+  "vacationStart": "2025-11-25",
+  "vacationEnd": "2025-12-10",
+  "substituteDoctor": "lékařka v ordinaci Mediclinic v Milíně, tel. 318 691 123, email praktik1-Milin@ordinace.mediclinic.cz"
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded, commented-out vacation popup HTML with a dynamic system driven by `vacation.json`
- A non-technical user can now manage vacation notices by editing a single JSON file via GitHub's web UI
- Also fixes: trailing space in mailto link, missing iframe title attributes, outdated copyright year (2023 → 2025)

## How it works

Edit `vacation.json` at the repo root:
```json
{
  "enabled": true,
  "vacationStart": "2025-11-25",
  "vacationEnd": "2025-12-10",
  "substituteDoctor": "lékařka v ordinaci Mediclinic v Milíně, tel. 318 691 123"
}
```

The popup automatically appears 14 days before vacation starts and hides after it ends. Set `enabled: false` to hide it regardless of dates.

## Changes

- **`vacation.json`** (new) — config file with inline instructions for the editor
- **`js/script.js`** — new fetch + template logic with pure `shouldShowPopup()` function, Czech date formatting, XSS escaping, ARIA attributes, silent error handling
- **`index.html`** / **`cenik.html`** — removed commented-out popup HTML, added placeholder div, fixed email link, added iframe titles, updated copyright year

## Test plan

- [ ] Enable vacation with today in range → popup appears on both pages
- [ ] Set `enabled: false` → no popup
- [ ] Set dates in the far future (>14 days) → no popup
- [ ] Set dates in the past → no popup
- [ ] Remove `substituteDoctor` field → popup shows without substitute section
- [ ] Delete `vacation.json` → no popup, no console errors
- [ ] Test close button, click outside, Escape key
- [ ] Verify mobile viewport rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)